### PR TITLE
Updating sha256 of  bookkeeper 4.9.1

### DIFF
--- a/bookkeeper.rb
+++ b/bookkeeper.rb
@@ -2,7 +2,7 @@ class Bookkeeper < Formula
   desc "BookKeeper is a replicated log service which can be used to build replicated state machines"
   homepage "http://bookkeeper.apache.org/"
   url "http://mirrors.estointernet.in/apache/bookkeeper/bookkeeper-4.9.1/bookkeeper-server-4.9.1-bin.tar.gz"
-  sha512 "a008cf49041a1d9a69bec62ea92daed5302babb7fb34fda06d48e0a77781eb4c4cb2aa6508435a4b9e70dce045ccd39b31829c3ac9723c9348e2a403d6e69a67"
+  sha256 "45af7fc4de69a0f1290d1bbfaefdfca5f7c54a039e3e362a58641087a8cdd42d"
   version "4.9.1"
 
   bottle :unneeded


### PR DESCRIPTION
sha256 of `bookkeeper/bookkeeper-4.9.1/bookkeeper-server-4.9.1-bin.tar.gz` is "45af7fc4de69a0f1290d1bbfaefdfca5f7c54a039e3e362a58641087a8cdd42d" : https://checker.apache.org/sums/45af7fc4de69a0f1290d1bbfaefdfca5f7c54a0

To test the homebrew formula - `brew install ChethanUK/homebrew-formulae/bookkeeper`: 
 
```
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (chethanuk/formulae).
==> Updated Formulae
chethanuk/formulae/bookkeeper

==> Installing bookkeeper from chethanuk/formulae
==> Downloading http://mirrors.estointernet.in/apache/bookkeeper/bookkeeper-4.9.1/bookkeeper-server-4.9.1-bin.tar.gz
######################################################################## 100.0%
==> Caveats
To have launchd start chethanuk/formulae/bookkeeper now and restart at login:
  brew services start chethanuk/formulae/bookkeeper
==> Summary
🍺  /usr/local/Cellar/bookkeeper/4.9.1: 147 files, 54.4MB, built in 42 seconds
```